### PR TITLE
Replaced backslashes with forwardslashes in path

### DIFF
--- a/ac.py
+++ b/ac.py
@@ -115,7 +115,7 @@ class LatexsqAcCommand(sublime_plugin.TextCommand):
         dir = os.path.join(tex_dir, os.path.dirname(prefix))
         base = os.path.basename(prefix)
         def on_done(target):
-            target_dir = (os.path.splitext(os.path.relpath(target, tex_dir))[0]).replace('\\', '/')
+            target_dir = (os.path.splitext(os.path.relpath(target, tex_dir))[0]).replace(os.sep, '/')
             self.replace(0, [target_dir], braces, point - len(prefix), point)
         listdir(view, dir, base, ext, on_done)
 


### PR DESCRIPTION
LaTeXSQ produced paths which contained backslashes. This made the paths invalid since backslash is an escape character in latex.
