### PR TITLE
Better (?) Shift+Enter behavior in lists

### DIFF
--- a/support/Default.sublime-keymap
+++ b/support/Default.sublime-keymap
@@ -20,6 +20,14 @@
             { "key": "selector", "operator": "equal", "operand": "meta.definition.list.latex" }
         ]
     },
+
+    // automatic addition of new \items [] when hitting Shift+Enter in a description environment
+    { "keys": ["shift+enter"], "command": "insert_snippet", "args": {"contents": "\n\\item [$1] $0"}, "context":
+        [
+            { "key": "selector", "operator": "equal", "operand": "meta.definition.description.latex" }
+        ]
+    },
+
     // Auto-pair brackets
     { "keys": ["("], "command": "insert_snippet", "args": {"contents": "($1)"}, "context":
         [

--- a/support/Default.sublime-keymap
+++ b/support/Default.sublime-keymap
@@ -15,7 +15,7 @@
     },
 
     // automatic addition of new \items when hitting Shift+Enter in a list environment
-    { "keys": ["shift+enter"], "command": "insert_snippet", "args": {"contents": "\n\\item$0"}, "context":
+    { "keys": ["shift+enter"], "command": "insert_snippet", "args": {"contents": "\n\\item $0"}, "context":
         [
             { "key": "selector", "operator": "equal", "operand": "meta.definition.list.latex" }
         ]

--- a/syntax/LaTeX Extended.tmLanguage
+++ b/syntax/LaTeX Extended.tmLanguage
@@ -68,12 +68,12 @@
 				<dict>
 					<key>name</key>
 					<string>support.function.latex</string>
-				</dict>			
+				</dict>
 				<key>3</key>
 				<dict>
 					<key>name</key>
 					<string>support.function.latex</string>
-				</dict>	
+				</dict>
 			</dict>
 			<key>end</key>
 			<string>}</string>
@@ -225,7 +225,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(\\begin)\{\s*((?:itemize|enumerate|description)\*?)\s*\}</string>
+			<string>(\\begin)\{\s*((?:itemize|enumerate)\*?)\s*\}</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -256,6 +256,47 @@
 			</dict>
 			<key>name</key>
 			<string>meta.definition.list.latex</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>$self</string>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>begin</key>
+			<string>(\\begin)\{\s*((?:description)\*?)\s*\}</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>support.function.latex</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>variable.parameter.latex</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>(\\end)\{\s*(\2)\s*\}</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>support.function.latex</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>variable.parameter.latex</string>
+				</dict>
+			</dict>
+			<key>name</key>
+			<string>meta.definition.description.latex</string>
 			<key>patterns</key>
 			<array>
 				<dict>


### PR DESCRIPTION
This is mostly a personal preference, but I think it would be appreciated by most.

As described in commit messages, I added a separate scope for ``description`` environments and a corresponding ``Shift+Enter`` snippet which automatically adds the ``[]`` that is usually used in descriptions:
```[latex]
\begin{description}
\item [Foo] Bar
\end{description}
```

It also bugged me that the current ``Shift+Enter`` snippet didn't insert a whitespace after ``\item``. 

Finally, I realized after committing my changes that I was behind your master branch, so I merged. However, this added an extra commit. Not sure what the workflow should be in that case (still new to collaborating on GitHub).    