### PR TITLE
Fix command line arguments for zathura PDF viewer

### DIFF
--- a/jump.py
+++ b/jump.py
@@ -103,7 +103,7 @@ class LatexPlusJumpToPdfCommand(sublime_plugin.TextCommand):
                     args = ["zathura", "--synctex-forward", dest, pdffile]
                 else:
                     sb_binary = linux_settings.get("sublime", "subl")
-                    args = ["zathura", "-s", "-x",
+                    args = ["zathura", "--synctex-pid=" + str(os.getpid()), "-x",
                             sb_binary + " %{input}:%{line}", pdffile]
                 print("about to run zathura with %s" % ' '.join(args))
                 subprocess.Popen(args)


### PR DESCRIPTION
Newer versions of this viewer accept the process PID as an argument instead of just plain "-s".

The "-s" argument is no longer recognised so without this change the viewer wouldn't work.